### PR TITLE
chore(ci): add --ignore-scripts to pnpm install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: lts/*
 
       - name: Install
-        run: pnpm install
+        run: pnpm install --ignore-scripts
 
       - name: Lint
         run: pnpm lint
@@ -43,7 +43,7 @@ jobs:
           node-version: lts/*
 
       - name: Install
-        run: pnpm install
+        run: pnpm install --ignore-scripts
 
       - name: Typecheck
         run: pnpm typecheck
@@ -62,7 +62,7 @@ jobs:
           node-version: lts/*
 
       - name: Install
-        run: pnpm install
+        run: pnpm install --ignore-scripts
 
       - name: Build
         run: pnpm build


### PR DESCRIPTION
Defense-in-depth against compromised transitive deps executing postinstall/prepare in CI. Motivated by the TanStack npm supply-chain compromise (May 2026).

No functional change — lint/typecheck/test do not depend on lifecycle scripts.