### PR TITLE
ci: adopt deny-all top-level workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 
-permissions:
-  contents: write
+permissions: {}
 
 on:
   push:
@@ -27,3 +26,5 @@ jobs:
       - run: npx changelogithub
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    permissions:
+      contents: write


### PR DESCRIPTION
Sets each workflow's top-level `permissions:` to `{}` (deny-all) and moves the previously top-level grants into the specific jobs that inherited them. **Effective permissions are unchanged for every job** — this just makes the grants explicit per job so a newly-added job can't silently inherit broad scopes.

Behavior-preserving mechanical change (validated: all touched workflows still parse; per-job effective scopes identical). Workflows whose jobs inherit the org default are left untouched for a manual per-job pass.

_Flagged by github-maintenance Workflow Permissions Audit._