### PR TITLE
ci: add autofix.ci

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,38 @@
+name: autofix.ci # needed to securely identify the workflow
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6
+
+      - name: Set node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: lts/*
+
+      - name: Install
+        run: pnpm install
+
+      # Apply Biome's formatting/lint fixes. Unfixable lint errors are CI's job
+      # to report (see ci.yml); don't let them block uploading the fixes.
+      - name: Apply fixes
+        run: pnpm lint || true
+
+      - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,3 @@
 {
-  "extends": [
-    "local>marimo-team/.github:renovate-config",
-    "config:recommended"
-  ]
+	"extends": ["local>marimo-team/.github:renovate-config", "config:recommended"]
 }


### PR DESCRIPTION
## What this does

Adds an `autofix.ci` workflow that runs on every PR (and on pushes to `main`). It installs deps exactly like the repo's own CI (`ci.yml`), runs Biome's fixer (`biome check --write .` via the existing `lint` script), and hands the result to `autofix-ci/action`, which **pushes the formatting/lint fixes back onto the PR branch**. Contributors never have to hand-fix formatting.

The [autofix.ci GitHub App](https://autofix.ci) is installed org-wide for `marimo-team` (confirmed by an org admin), so this works as soon as it's merged — no per-repo setup needed.

## How it composes with the existing lint gate

This does not replace CI's lint check — it complements it. The existing `ci.yml` lint job stays the hard gate that fails the build on unfixable problems. autofix.ci just removes the busywork: anything Biome *can* fix automatically gets pushed to the branch, so the lint gate only ever fails on things that genuinely need a human. The fixer runs with `|| true` so unfixable lint errors don't block uploading the fixes that did apply (CI still reports them).

## Included fix: `renovate.json`

Running the fixer locally surfaced one pre-existing formatting drift: `renovate.json` (left un-formatted by the recent Renovate config migration) gets reformatted by Biome. That fix is included in this PR so the tree is clean and future autofix runs are no-ops. No behavior change — same `extends` list, reformatted to Biome's style.

## Verification

- Cloned, `pnpm install`, ran the exact fixer the workflow uses. Only diff was the `renovate.json` reformat noted above (now committed); re-running the fixer is a clean no-op.
- Workflow YAML parses and passes `actionlint` (0 issues).
- Action/toolchain versions and SHA pins (checkout/pnpm/node all `# v6`) mirror `ci.yml`.
- Workflow `name` is exactly `autofix.ci` (required — the service identifies the workflow by name for security) and the `autofix-ci/action` step runs last.

Part of the marimo-team engineering-excellence initiative.
