### PR TITLE
docs: add AGENTS.md with CLAUDE.md symlink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# react-slotz
+
+Teleport React components to anywhere in the react-tree (slot/fill). Published to npm as `@marimo-team/react-slotz`.
+
+## Development
+
+```bash
+pnpm install
+pnpm test        # vitest
+pnpm lint        # biome check --write . (autofix.ci runs this on PRs)
+pnpm typecheck   # tsc --noEmit
+pnpm build       # unbuild -> dist/
+pnpm ci          # typecheck + lint + test
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
This adds an `AGENTS.md` as the canonical agent-context doc, with `CLAUDE.md` as a symlink to it (`ln -s AGENTS.md CLAUDE.md`) so both Claude and other coding agents read the same file. Part of the marimo-team engineering-excellence initiative to standardize agent docs across repos. The content is deliberately minimal — a one-line overview plus verified development commands — because these files load into every agent context, so fewer tokens is better.